### PR TITLE
Add portfolio webpage

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Alankrit Mishra - Portfolio</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-image: url('image.jpg');
+            background-size: cover;
+        }
+        .overlay {
+            background: rgba(255, 255, 255, 0.8);
+            min-height: 100vh;
+            padding: 20px;
+        }
+        header {
+            text-align: center;
+            padding-top: 20px;
+        }
+        header h1 {
+            margin: 0;
+        }
+        section {
+            margin: 40px 0;
+        }
+        .skills li {
+            margin-bottom: 5px;
+        }
+        footer {
+            text-align: center;
+            font-size: 0.9em;
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+<div class="overlay">
+    <header>
+        <h1>ALANKRIT MISHRA</h1>
+        <p>alano21816@gmail.com | +1 (412) 801-3726 | <a href="https://www.linkedin.com/in/alankritrmishra/">LinkedIn</a></p>
+    </header>
+
+    <section>
+        <h2>Professional Summary</h2>
+        <p>A highly skilled and solutions-oriented Senior Cloud Engineer with over 6 years of experience designing and managing public cloud architectures (AWS, GCP, Azure). Expert in Infrastructure as Code, monitoring, and system optimization.</p>
+    </section>
+
+    <section>
+        <h2>Skills & Certifications</h2>
+        <ul class="skills">
+            <li>Languages: Java, C/C++, SQL, PL/SQL, Python, Golang</li>
+            <li>Cloud Computing: AWS, GCP, Azure</li>
+            <li>Configuration Management: Chef, Ansible, Terraform</li>
+            <li>Source Code Management: Git, GitHub, GitLab, Bitbucket</li>
+            <li>Monitoring: Grafana, Splunk, CloudWatch, Prometheus, DataDog</li>
+            <li>Virtualization: Docker, VMware, Kubernetes</li>
+            <li>Scripting: Shell, Python, Scala, Go, JavaScript</li>
+            <li>Web/Application Servers: Tomcat, WebLogic, JBoss, Nginx</li>
+            <li>CI/CD: Jenkins, GitLab CI/CD, Argo CD</li>
+            <li>Operating systems: Windows, Linux, RHEL, Mac OS X, CentOS</li>
+        </ul>
+        <p><strong>Certifications:</strong> AWS Certified Associate Solution Architect, CAPM, Certified Kubernetes Administrator</p>
+    </section>
+
+    <section>
+        <h2>Education</h2>
+        <p><strong>University of Pittsburgh, Joseph M. Katz Graduate School of Business</strong> &mdash; Master of Science in Management Information Systems, May 2022</p>
+        <p><strong>Visvesvaraya Technological University</strong> &mdash; Bachelor of Engineering in Electronics & Communication, May 2016</p>
+    </section>
+
+    <section>
+        <h2>Projects</h2>
+        <p>Coming soon! This section will highlight select projects and case studies demonstrating my expertise in cloud engineering and DevOps.</p>
+    </section>
+
+    <footer>
+        &copy; 2023 Alankrit Mishra
+    </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `portfolio.html` as a simple personal website derived from resume

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f64a52d548321a17627c8f05cfc30